### PR TITLE
Use React.Children.map instead of children.map

### DIFF
--- a/Picker.js
+++ b/Picker.js
@@ -13,8 +13,8 @@ export default class Picker extends Component {
 
   handlePress() {
     const { children, onValueChange, prompt } = this.props
-    const labels = children.map(child => child.props.label)
-    const values = children.map(child => child.props.value)
+    const labels = React.Children.map(children, (child) => child.props.label)
+    const values = React.Children.map(children, (child) => child.props.value)
     ActionSheetIOS.showActionSheetWithOptions(
       {
         title: prompt,
@@ -31,8 +31,8 @@ export default class Picker extends Component {
 
   render() {
     const { children, style, textStyle } = this.props
-    const labels = children.map(child => child.props.label)
-    const values = children.map(child => child.props.value)
+    const labels = React.Children.map(children, (child) => child.props.label)
+    const values = React.Children.map(children, (child) => child.props.value)
     const flatStyle = (style ? StyleSheet.flatten(style) : {})
 
     if (Platform.OS === 'ios') {


### PR DESCRIPTION
Using children.map Picker.Item elements cannot be added dynamically and using the following code to loop over elements do not work:

```javascript
{
       Object.keys(options).map((o,i) =>
               <Picker.Item label={options[o]} value={o} key={i} />
        )
}
```

Looping through React Children should be done using React.Children.map
https://reactjs.org/docs/react-api.html#react.children